### PR TITLE
Add goal-to-schedule engine

### DIFF
--- a/backend/api/goals.js
+++ b/backend/api/goals.js
@@ -1,0 +1,17 @@
+const express = require('express');
+const router = express.Router();
+const { parseGoal } = require('../../shared/parseGoal');
+const { schedulePlan } = require('../../shared/schedulePlan');
+
+// POST /api/goals
+router.post('/', (req, res) => {
+  const { text } = req.body;
+  if (!text) return res.status(400).json({ error: 'text required' });
+
+  const goals = parseGoal(text);
+  const schedule = schedulePlan(goals);
+
+  res.json({ schedule });
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -8,6 +8,7 @@ app.use(express.json());
 
 app.use('/api/tasks', require('./api/tasks'));
 app.use('/api/instruction', require('./api/instructions'));
+app.use('/api/goals', require('./api/goals'));
 
 mongoose.connect('mongodb://localhost:27017/assistant-ai', {
   useNewUrlParser: true,

--- a/frontend/hooks/useGoalPlanner.ts
+++ b/frontend/hooks/useGoalPlanner.ts
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+
+interface ScheduledTask {
+  text: string;
+  startTime: string;
+}
+
+export function useGoalPlanner() {
+  const [schedule, setSchedule] = useState<ScheduledTask[]>([]);
+
+  async function planGoals(text: string) {
+    const res = await fetch('http://localhost:3001/api/goals', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text }),
+    });
+
+    if (!res.ok) {
+      throw new Error('Failed to plan goals');
+    }
+
+    const data = await res.json();
+    setSchedule(data.schedule);
+    return data.schedule as ScheduledTask[];
+  }
+
+  return { schedule, planGoals };
+}

--- a/shared/parseGoal.ts
+++ b/shared/parseGoal.ts
@@ -1,0 +1,25 @@
+export type Goal = {
+  text: string;
+  priority: 'high' | 'medium' | 'low';
+};
+
+/**
+ * Parse free-form goal text into a list of structured goal objects.
+ * Very naive implementation that splits by commas and the word "and".
+ */
+export function parseGoal(input: string): Goal[] {
+  const cleaned = input
+    .replace(/try to|please|i (?:need|want) to/gi, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  const segments = cleaned
+    .split(/,| and /i)
+    .map(s => s.trim())
+    .filter(Boolean);
+
+  return segments.map(text => ({
+    text,
+    priority: /must|need|by \d/.test(text) ? 'high' : /try|should/.test(text) ? 'medium' : 'low',
+  }));
+}

--- a/shared/schedulePlan.ts
+++ b/shared/schedulePlan.ts
@@ -1,0 +1,18 @@
+import { Goal } from './parseGoal';
+
+export interface ScheduledTask {
+  text: string;
+  startTime: string;
+}
+
+/**
+ * Simple scheduler that assigns each goal an hour block starting now.
+ * Traffic and other constraints would be injected here in the future.
+ */
+export function schedulePlan(goals: Goal[]): ScheduledTask[] {
+  const base = Date.now();
+  return goals.map((g, i) => ({
+    text: g.text,
+    startTime: new Date(base + i * 60 * 60 * 1000).toISOString(),
+  }));
+}


### PR DESCRIPTION
## Summary
- create basic goal parser and scheduler
- expose `/api/goals` endpoint
- wire endpoint in server
- add React hook for planning goals

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68450931a1fc8333abee04ed4fbe2f54